### PR TITLE
feat: retrofit all Tier 1-2 contracts with Eiffel DbC types

### DIFF
--- a/contracts/attention-kernel-v1.yaml
+++ b/contracts/attention-kernel-v1.yaml
@@ -18,6 +18,19 @@ equations:
       - "Output rows are convex combinations of V rows"
 
 proof_obligations:
+  - type: precondition
+    property: "Q, K, V finite and compatible shapes"
+    formal: "all(is_finite(Q)) and all(is_finite(K)) and all(is_finite(V)) and cols(Q) = cols(K) and rows(K) = rows(V)"
+    applies_to: all
+  - type: postcondition
+    property: "Output shape and attention weights normalized"
+    formal: "shape(output) = (rows(Q), cols(V)) and Σ_j attn_{ij} = 1 for all i"
+    requires: "Q, K, V finite and compatible shapes"
+    applies_to: all
+  - type: frame
+    property: "Q, K, V unchanged"
+    formal: "input matrices Q, K, V are not modified by kernel"
+    applies_to: all
   - type: invariant
     property: "Attention weights normalize"
     formal: "Σ_j softmax(QK^T/√d_k)_{ij} = 1 for all i"
@@ -82,6 +95,22 @@ falsification_tests:
     test: "proptest: verify 0 < attn_ij < 1 for random Q,K"
     if_fails: "Softmax output outside (0,1) range"
 
+  - id: FALSIFY-ATT-006
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf, incompatible shapes)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-ATT-007
+    rule: "Frame condition"
+    prediction: "Q, K, V unchanged after kernel call"
+    test: "proptest: clone inputs, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-ATT-008
+    rule: "Postcondition - output shape"
+    prediction: "Output has shape (rows(Q), cols(V))"
+    test: "proptest: random valid inputs, verify output shape"
+    if_fails: "Output allocation mismatch"
+
 kani_harnesses:
   - id: KANI-ATT-001
     obligation: ATT-INV-001
@@ -97,7 +126,7 @@ qa_gate:
     - "weight_normalization"
     - "output_convexity"
     - "scaling_factor"
-  pass_criteria: "All 5 falsification tests pass"
+  pass_criteria: "All 8 falsification tests pass"
   falsification: "Use 1/d_k instead of 1/√d_k for scaling"
 
 simd_dispatch:

--- a/contracts/flash-attention-v1.yaml
+++ b/contracts/flash-attention-v1.yaml
@@ -6,7 +6,7 @@ metadata:
   references:
     - "Dao et al. (2022) FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness"
     - "Dao (2023) FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning"
-  depends_on: ["softmax-kernel-v1"]
+  depends_on: ["softmax-kernel-v1", "attention-kernel-v1"]
 
 equations:
   flash_attention:
@@ -19,6 +19,23 @@ equations:
       - "Online softmax: running max and sum across tiles"
 
 proof_obligations:
+  - type: precondition
+    property: "Q, K, V finite and block size positive"
+    formal: "all(is_finite(Q)) and all(is_finite(K)) and all(is_finite(V)) and block_size > 0"
+    applies_to: all
+  - type: postcondition
+    property: "Output matches standard attention within tolerance"
+    formal: "|FlashAttn(Q,K,V) - StdAttn(Q,K,V)| < ε for all elements"
+    requires: "Q, K, V finite and block size positive"
+    applies_to: all
+  - type: frame
+    property: "Q, K, V unchanged"
+    formal: "input matrices Q, K, V are not modified by kernel"
+    applies_to: all
+  - type: subcontract
+    property: "FlashAttention refines standard attention"
+    formal: "pre(Attention) → pre(FlashAttention) ∧ post(FlashAttention) → post(Attention)"
+    parent_contract: "attention-kernel-v1"
   - type: equivalence
     property: "Matches standard attention"
     formal: "|FlashAttn(Q,K,V) - StdAttn(Q,K,V)| < ε"
@@ -36,6 +53,11 @@ proof_obligations:
     property: "Attention weight conservation"
     formal: "Each output row is weighted mean of V rows"
     applies_to: all
+
+subcontract:
+  parent_contract: "attention-kernel-v1"
+  relationship: "FlashAttention is an IO-aware tiled implementation of standard attention"
+  equivalence: "|FlashAttn(Q,K,V) - StdAttn(Q,K,V)| < ε"
 
 kernel_structure:
   phases:
@@ -74,6 +96,28 @@ falsification_tests:
     test: "direct test with small inputs"
     if_fails: "Edge case in tile loop bounds"
 
+  - id: FALSIFY-FA-005
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf, block_size = 0)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-FA-006
+    rule: "Frame condition"
+    prediction: "Q, K, V unchanged after kernel call"
+    test: "proptest: clone inputs, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-FA-007
+    rule: "Postcondition - output shape"
+    prediction: "Output matches standard attention within tolerance"
+    test: "proptest: random valid inputs, verify output matches standard attention"
+    if_fails: "Output allocation mismatch"
+
+  - id: FALSIFY-FA-008
+    rule: "Subcontract - FlashAttention refines Attention"
+    prediction: "Any input accepted by standard Attention is also accepted by FlashAttention"
+    test: "proptest: random Q,K,V valid for standard attention, verify FlashAttention accepts"
+    if_fails: "FlashAttention strengthens precondition (rejects inputs standard accepts)"
+
 kani_harnesses:
   - id: KANI-FA-001
     obligation: FA-EQ-001
@@ -89,7 +133,7 @@ qa_gate:
     - "equivalence"
     - "online_softmax"
     - "weight_normalization"
-  pass_criteria: "All 4 falsification tests pass"
+  pass_criteria: "All 8 falsification tests pass"
   falsification: "Skip rescaling step in tile accumulation"
 
 simd_dispatch:

--- a/contracts/gelu-kernel-v1.yaml
+++ b/contracts/gelu-kernel-v1.yaml
@@ -47,6 +47,19 @@ equations:
 
 # Proof obligations: formal properties that must hold for any correct implementation
 proof_obligations:
+  - type: precondition
+    property: "Input finite"
+    formal: "all(is_finite(x_i)) for input vector x"
+    applies_to: all
+  - type: postcondition
+    property: "Output same length and all finite"
+    formal: "len(output) = len(input) and all(is_finite(output_i))"
+    requires: "Input finite"
+    applies_to: all
+  - type: frame
+    property: "Input unchanged"
+    formal: "input vector x is not modified by kernel"
+    applies_to: all
   - type: bound
     property: "Non-negativity for positive inputs"
     formal: "x > 0 implies GELU(x) >= 0"
@@ -137,6 +150,22 @@ falsification_tests:
     test: "proptest with large magnitude x"
     if_fails: "Numerical overflow in exp or tanh for extreme inputs"
 
+  - id: FALSIFY-GE-007
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-GE-008
+    rule: "Frame condition"
+    prediction: "Input unchanged after kernel call"
+    test: "proptest: clone input, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-GE-009
+    rule: "Postcondition - output shape"
+    prediction: "Output has same length as input"
+    test: "proptest: random valid inputs, verify output length"
+    if_fails: "Output allocation mismatch"
+
 # Kani bounded model checking harnesses for formal verification
 kani_harnesses:
   - id: KANI-GE-001
@@ -165,5 +194,5 @@ qa_gate:
     - "odd_symmetry"
     - "simd_equivalence"
     - "approximation_accuracy"
-  pass_criteria: "All 6 falsification tests pass + Kani harnesses verify"
+  pass_criteria: "All 9 falsification tests pass + Kani harnesses verify"
   falsification: "Replace CDF with constant 0.5 to reduce GELU to 0.5*x"

--- a/contracts/layernorm-kernel-v1.yaml
+++ b/contracts/layernorm-kernel-v1.yaml
@@ -25,6 +25,19 @@ equations:
       - "sigma^2 = 0 iff x is constant"
 
 proof_obligations:
+  - type: precondition
+    property: "Inputs finite and compatible"
+    formal: "all(is_finite(x_i)) and all(is_finite(gamma_i)) and len(x) = len(gamma) and eps > 0"
+    applies_to: all
+  - type: postcondition
+    property: "Output same length, all finite, centered"
+    formal: "len(output) = len(input) and all(is_finite(output_i)) and |mean(output)| < eps when gamma=1, beta=0"
+    requires: "Inputs finite and compatible"
+    applies_to: all
+  - type: frame
+    property: "Input, weight, bias unchanged"
+    formal: "input x, weight gamma, and bias beta are not modified by kernel"
+    applies_to: all
   - type: invariant
     property: "Centering"
     formal: "|mean(LN(x)) - mean(beta)| < eps when gamma = 1"
@@ -75,7 +88,7 @@ proof_obligations:
       notes: "mean(x+c) = mean(x)+c, so centered values unchanged, variance unchanged"
 
 verification_summary:
-  total_obligations: 6
+  total_obligations: 9
   l2_property_tested: 6
   l3_kani_proved: 3
   l4_lean_proved: 2
@@ -150,6 +163,22 @@ falsification_tests:
     test: "proptest with constant vectors"
     if_fails: "Division by near-zero variance not handled"
 
+  - id: FALSIFY-LN-008
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf, mismatched lengths, eps <= 0)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-LN-009
+    rule: "Frame condition"
+    prediction: "Input, weight, bias unchanged after kernel call"
+    test: "proptest: clone inputs, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-LN-010
+    rule: "Postcondition - output shape"
+    prediction: "Output has same length as input"
+    test: "proptest: random valid inputs, verify output length"
+    if_fails: "Output allocation mismatch"
+
 kani_harnesses:
   - id: KANI-LN-001
     obligation: LN-INV-001
@@ -183,5 +212,5 @@ qa_gate:
     - "denominator_safety"
     - "simd_equivalence"
     - "idempotency"
-  pass_criteria: "All 7 falsification tests pass + Kani harnesses verify"
+  pass_criteria: "All 10 falsification tests pass + Kani harnesses verify"
   falsification: "Remove epsilon from denominator sqrt"

--- a/contracts/matmul-kernel-v1.yaml
+++ b/contracts/matmul-kernel-v1.yaml
@@ -24,6 +24,19 @@ equations:
       - "|q_dot - f32_dot| ≤ quantization_error_bound"
 
 proof_obligations:
+  - type: precondition
+    property: "A, B finite and dimensions compatible"
+    formal: "all(is_finite(A)) and all(is_finite(B)) and cols(A) = rows(B)"
+    applies_to: all
+  - type: postcondition
+    property: "Output shape and all finite"
+    formal: "shape(output) = (rows(A), cols(B)) and all(is_finite(output))"
+    requires: "A, B finite and dimensions compatible"
+    applies_to: all
+  - type: frame
+    property: "A, B unchanged"
+    formal: "input matrices A and B are not modified by kernel"
+    applies_to: all
   - type: invariant
     property: "Output shape correctness"
     formal: "shape(A @ B) = (rows(A), cols(B))"
@@ -86,6 +99,22 @@ falsification_tests:
     test: "proptest with identity matrices"
     if_fails: "Off-by-one in loop bounds"
 
+  - id: FALSIFY-MM-006
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf, incompatible dimensions)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-MM-007
+    rule: "Frame condition"
+    prediction: "A, B unchanged after kernel call"
+    test: "proptest: clone inputs, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-MM-008
+    rule: "Postcondition - output shape"
+    prediction: "Output has shape (rows(A), cols(B))"
+    test: "proptest: random valid inputs, verify output shape"
+    if_fails: "Output allocation mismatch"
+
 kani_harnesses:
   - id: KANI-MM-001
     obligation: MM-INV-001
@@ -101,7 +130,7 @@ qa_gate:
     - "shape_correctness"
     - "numerical_accuracy"
     - "simd_equivalence"
-  pass_criteria: "All 5 falsification tests pass"
+  pass_criteria: "All 8 falsification tests pass"
   falsification: "Swap row/column indices in inner loop"
 
 simd_dispatch:

--- a/contracts/silu-kernel-v1.yaml
+++ b/contracts/silu-kernel-v1.yaml
@@ -26,6 +26,19 @@ equations:
       - "sigmoid(-x) = 1 - sigmoid(x) (symmetry)"
 
 proof_obligations:
+  - type: precondition
+    property: "Input finite"
+    formal: "all(is_finite(x_i)) for input vector x"
+    applies_to: all
+  - type: postcondition
+    property: "Output same length and correct"
+    formal: "len(output) = len(input) and output_i = x_i * sigmoid(x_i)"
+    requires: "Input finite"
+    applies_to: all
+  - type: frame
+    property: "Input unchanged"
+    formal: "input vector x is not modified by kernel"
+    applies_to: all
   - type: invariant
     property: "Zero preservation"
     formal: "SiLU(0) = 0"
@@ -55,7 +68,7 @@ proof_obligations:
     applies_to: all
 
 verification_summary:
-  total_obligations: 5
+  total_obligations: 8
   l2_property_tested: 5
   l3_kani_proved: 3
   l4_lean_proved: 1
@@ -119,6 +132,22 @@ falsification_tests:
     test: "proptest with large negative x"
     if_fails: "exp overflow for large negative input"
 
+  - id: FALSIFY-SI-007
+    rule: "Precondition violation"
+    prediction: "kernel panics or returns Err on invalid input"
+    test: "proptest with invalid inputs (NaN, Inf)"
+    if_fails: "Missing input validation"
+  - id: FALSIFY-SI-008
+    rule: "Frame condition"
+    prediction: "Input unchanged after kernel call"
+    test: "proptest: clone input, call kernel, assert unchanged"
+    if_fails: "Kernel corrupts input buffer"
+  - id: FALSIFY-SI-009
+    rule: "Postcondition - output shape"
+    prediction: "Output has same length as input"
+    test: "proptest: random valid inputs, verify output length"
+    if_fails: "Output allocation mismatch"
+
 kani_harnesses:
   - id: KANI-SI-001
     obligation: SI-INV-001
@@ -151,5 +180,5 @@ qa_gate:
     - "lower_bound"
     - "positive_monotonicity"
     - "simd_equivalence"
-  pass_criteria: "All 6 falsification tests pass + Kani harnesses verify"
+  pass_criteria: "All 9 falsification tests pass + Kani harnesses verify"
   falsification: "Replace sigmoid with constant 0.5"

--- a/crates/provable-contracts/tests/validate_contracts.rs
+++ b/crates/provable-contracts/tests/validate_contracts.rs
@@ -254,8 +254,8 @@ fn contract_data_integrity() {
     }
 
     assert_eq!(total_eq, 395, "Total equations changed");
-    assert_eq!(total_ob, 632, "Total obligations changed");
-    assert_eq!(total_ft, 673, "Total falsification tests changed");
+    assert_eq!(total_ob, 651, "Total obligations changed");
+    assert_eq!(total_ft, 692, "Total falsification tests changed");
     assert_eq!(total_kani, 229, "Total Kani harnesses changed");
 
     assert!(


### PR DESCRIPTION
## Summary

- Retrofit 6 remaining Tier 1-2 contracts with precondition/postcondition/frame obligations
- Add subcontract to flash-attention (refines attention-kernel-v1)
- Enhance `pv explain` to render DbC-specific fields (requires/applies_to_phase/parent_contract)
- All 13 Tier 1-2 kernel contracts now have DbC obligations

## Contracts Modified

| Contract | DbC Types Added |
|---|---|
| silu-kernel-v1 | precondition, postcondition, frame |
| gelu-kernel-v1 | precondition, postcondition, frame |
| layernorm-kernel-v1 | precondition, postcondition, frame |
| attention-kernel-v1 | precondition, postcondition, frame |
| flash-attention-v1 | precondition, postcondition, frame, subcontract |
| matmul-kernel-v1 | precondition, postcondition, frame |

## Registry Totals

- 395 equations, 651 obligations (+19), 692 FTs (+19), 229 Kani
- 1230 tests pass

## Test plan

- [x] `cargo test --workspace -- --skip cross_project` passes
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `pv validate` passes for all modified contracts
- [x] `pv explain` renders new DbC fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)